### PR TITLE
Fix error when in OK not fill email

### DIFF
--- a/src/main/java/ru/playa/keycloak/modules/ok/OKIdentityProvider.java
+++ b/src/main/java/ru/playa/keycloak/modules/ok/OKIdentityProvider.java
@@ -87,7 +87,7 @@ public class OKIdentityProvider
             throw new IllegalArgumentException(MessageUtils.email("OK"));
         }
 
-        String username = getJsonProperty(profile, "login");
+        String username = getConfig().getAlias() + "." + getJsonProperty(profile, "uid");
         if (StringUtils.isNullOrEmpty(username)) {
             user.setUsername(email);
         } else {


### PR DESCRIPTION
Когда снята галка "Email required", при авторизации происходит ошибка, т.к. поле login не приходит от провайдера.